### PR TITLE
Translate task and resource labels to Japanese

### DIFF
--- a/openproj_core/src/com/projity/strings/client.properties
+++ b/openproj_core/src/com/projity/strings/client.properties
@@ -29,7 +29,7 @@
 # use the latest text at http://www.projity.com/license for your modifications.
 # You may not remove this license text from the source files.]
 
-# Attribution Information: Attribution Copyright Notice: Copyright © 2006, 2007
+# Attribution Information: Attribution Copyright Notice: Copyright Â© 2006, 2007
 # Projity, Inc. Attribution Phrase (not exceeding 10 words): Powered by OpenProj,
 # an open source solution from Projity. Attribution URL: http://www.projity.com
 # Graphic Image as provided in the Covered Code as file:  openproj_logo.png with
@@ -456,14 +456,14 @@ FieldDialog.TaskInformation=Task Information
 Field.remainingWork=Remaining Work
 # R/D is an abbreviation for Request / Demand; a resouce is requested or is demanded
 Field.requestDemandType=R/D
-Field.resourceAvailability=Resource Availability
-Field.resourceGroup=Resource Group
-Field.resourceId=Resource ID
-Field.resourceInitials=Resource Initials
-Field.resourceNames=Resource Names
-Field.resourcePhonetics=Resource Phonetics
-Field.resourcePool=Resource Pool
-Field.resourceType=Type
+Field.resourceAvailability=\u8981\u54e1\u5229\u7528\u53ef\u80fd
+Field.resourceGroup=\u8981\u54e1\u30b0\u30eb\u30fc\u30d7
+Field.resourceId=\u8981\u54e1ID
+Field.resourceInitials=\u8981\u54e1\u30a4\u30cb\u30b7\u30e3\u30eb
+Field.resourceNames=\u8981\u54e1\u540d
+Field.resourcePhonetics=\u8981\u54e1\u30d5\u30ea\u30ac\u30ca
+Field.resourcePool=\u8981\u54e1\u30d7\u30fc\u30eb
+Field.resourceType=\u8981\u54e1\u7a2e\u5225
 Field.responsePending=Response Pending
 Field.resume=Resume
 Field.risk=Risk
@@ -496,7 +496,7 @@ Field.sv=SV
 Field.svPercent=SV Percent
 Field.taskCalendar=Task Calendar
 Field.taskId=Task ID
-Field.taskName=Task Name
+Field.taskName=\u5de5\u7a0b\u540d
 Field.taskOutlineNumber=Task Outline Number
 Field.taskSummaryName=Task Summary Name
 Field.taskType=Type

--- a/projectlibre_core/src/org/projectlibre/strings/client.properties
+++ b/projectlibre_core/src/org/projectlibre/strings/client.properties
@@ -29,7 +29,7 @@
 # use the latest text at http://www.projity.com/license for your modifications.
 # You may not remove this license text from the source files.]
 
-# Attribution Information: Attribution Copyright Notice: Copyright © 2006, 2007
+# Attribution Information: Attribution Copyright Notice: Copyright Â© 2006, 2007
 # Projity, Inc. Attribution Phrase (not exceeding 10 words): Powered by OpenProj,
 # an open source solution from Projity. Attribution URL: http://www.projity.com
 # Graphic Image as provided in the Covered Code as file:  openproj_logo.png with
@@ -456,14 +456,14 @@ FieldDialog.TaskInformation=Task Information
 Field.remainingWork=Remaining Work
 # R/D is an abbreviation for Request / Demand; a resouce is requested or is demanded
 Field.requestDemandType=R/D
-Field.resourceAvailability=Resource Availability
-Field.resourceGroup=Resource Group
-Field.resourceId=Resource ID
-Field.resourceInitials=Resource Initials
-Field.resourceNames=Resource Names
-Field.resourcePhonetics=Resource Phonetics
-Field.resourcePool=Resource Pool
-Field.resourceType=Type
+Field.resourceAvailability=\u8981\u54e1\u5229\u7528\u53ef\u80fd
+Field.resourceGroup=\u8981\u54e1\u30b0\u30eb\u30fc\u30d7
+Field.resourceId=\u8981\u54e1ID
+Field.resourceInitials=\u8981\u54e1\u30a4\u30cb\u30b7\u30e3\u30eb
+Field.resourceNames=\u8981\u54e1\u540d
+Field.resourcePhonetics=\u8981\u54e1\u30d5\u30ea\u30ac\u30ca
+Field.resourcePool=\u8981\u54e1\u30d7\u30fc\u30eb
+Field.resourceType=\u8981\u54e1\u7a2e\u5225
 Field.responsePending=Response Pending
 Field.resume=Resume
 Field.risk=Risk
@@ -496,7 +496,7 @@ Field.sv=SV
 Field.svPercent=SV Percent
 Field.taskCalendar=Task Calendar
 Field.taskId=Task ID
-Field.taskName=Task Name
+Field.taskName=\u5de5\u7a0b\u540d
 Field.taskOutlineNumber=Task Outline Number
 Field.taskSummaryName=Task Summary Name
 Field.taskType=Type


### PR DESCRIPTION
## Summary
- Localize task name label to Japanese construction terminology
- Rename resource-related labels to Japanese equivalents

## Testing
- `ant test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b69a3fe87883268216488d06513570